### PR TITLE
Email Flow

### DIFF
--- a/lib/tozny/realm.rb
+++ b/lib/tozny/realm.rb
@@ -219,6 +219,24 @@ module Tozny
       raw_call request_obj
     end
 
+    # Create an email challenge session
+    # @return [Hash] a hash of the session and presence for the challenge
+    # @param [String] destination The email address to which we will send a challenge
+    # @param [String] callback    URL to which Tozny should submit signed email verificaton
+    # @param [String] hostname    Hostname for the generated OTP URL
+    # @param [Bool]   send        Flag whether or not to send the email (if false will return the OTP URL instead)
+    def email_challenge(destination, callback = nil, hostname = nil, send = true)
+      request_obj = {
+          method: 'realm.email_challenge',
+          destination: destination,
+          send: !! send ? 'yes' : 'no' # Hacky double-bang to convert nil to false and anything else into a boolean
+      }
+      request_obj['callback'] = callback unless callback.nil?
+      request_obj['hostname'] = hostname unless hostname.nil?
+
+      raw_call request_obj
+    end
+
     # Shorthand method to send an 6-digit OTP via SMS without a presence token
     # @param destination @see(otp_challenge)
     # @param data @see(otp_challenge)

--- a/lib/tozny/realm.rb
+++ b/lib/tozny/realm.rb
@@ -196,9 +196,10 @@ module Tozny
     # @param [String] destination the destination for the OTP. For an SMS OTP, this should be a phone number
     # @param [String] presence can be used instead of 'type' and 'destination': an OTP presence provided by the TOZNY API
     # @param [Object] data optional passthru data to be added to the signed response on a successful request
+    # @param [String] context One of "verify," "authenticate," or "enroll"
     # @raise ArgumentError when not enough information to submit an OTP request
     # @raise ArgumentError on invalid request type
-    def otp_challenge(type = nil, destination = nil, presence = nil, data = nil)
+    def otp_challenge(type = nil, destination = nil, presence = nil, data = nil, context = nil)
       raise ArgumentError, 'must provide either a presence or a type and destination' if (type.nil? || destination.nil?) && presence.nil?
       request_obj = {
         method: 'realm.otp_challenge'
@@ -216,6 +217,9 @@ module Tozny
       else
         request_obj[:presence] = presence
       end
+
+      request_obj[:context] = context unless context.nil?
+
       raw_call request_obj
     end
 

--- a/lib/tozny/realm.rb
+++ b/lib/tozny/realm.rb
@@ -225,23 +225,25 @@ module Tozny
 
     # Create a magic link challenge session
     #
-    # @param [String] destination The email address or phone number to which we will send a challenge
-    # @param [String] context     One of "verify," "authenticate," or "enroll"
-    # @param [String] callback    URL to which Tozny should submit signed link verification
-    # @param [String] hostname    Hostname for the generated OTP URL
-    # @param [Bool]   send        Flag whether or not to send the email (if false will return the OTP URL instead)
+    # @param [String]  destination The email address or phone number to which we will send a challenge
+    # @param [String]  endpoint    URL endpoint to use as a base for the challenge URL
+    # @param [Integer] lifespan    Number of seconds for which the challenge URL is valid
+    # @param [String]  context     One of "verify," "authenticate," or "enroll"
+    # @param [Bool]    send        Flag whether or not to send the email (if false will return the OTP URL instead)
+    # @param [String]  data        JSON-encoded string of data to be signed along with the request
     #
     # @return [Hash] a hash of the session and presence for the challenge
     #
-    def link_challenge(destination, context = nil, callback = nil, hostname = nil, send = true)
+    def link_challenge(destination, endpoint, lifespan = nil, context = nil, send = true, data = nil)
       request_obj = {
           method: 'realm.link_challenge',
           destination: destination,
+          endpoint: endpoint,
           send: !! send ? 'yes' : 'no' # Hacky double-bang to convert nil to false and anything else into a boolean
       }
+      request_obj['lifespan'] = lifespan unless lifespan.nil?
       request_obj['context'] = context unless context.nil?
-      request_obj['callback'] = callback unless callback.nil?
-      request_obj['hostname'] = hostname unless hostname.nil?
+      request_obj['data'] = data unless data.nil?
 
       raw_call request_obj
     end

--- a/lib/tozny/realm.rb
+++ b/lib/tozny/realm.rb
@@ -219,18 +219,23 @@ module Tozny
       raw_call request_obj
     end
 
-    # Create an email challenge session
-    # @return [Hash] a hash of the session and presence for the challenge
-    # @param [String] destination The email address to which we will send a challenge
-    # @param [String] callback    URL to which Tozny should submit signed email verificaton
+    # Create a magic link challenge session
+    #
+    # @param [String] destination The email address or phone number to which we will send a challenge
+    # @param [String] context     One of "verify," "authenticate," or "enroll"
+    # @param [String] callback    URL to which Tozny should submit signed link verification
     # @param [String] hostname    Hostname for the generated OTP URL
     # @param [Bool]   send        Flag whether or not to send the email (if false will return the OTP URL instead)
-    def email_challenge(destination, callback = nil, hostname = nil, send = true)
+    #
+    # @return [Hash] a hash of the session and presence for the challenge
+    #
+    def link_challenge(destination, context = nil, callback = nil, hostname = nil, send = true)
       request_obj = {
-          method: 'realm.email_challenge',
+          method: 'realm.link_challenge',
           destination: destination,
           send: !! send ? 'yes' : 'no' # Hacky double-bang to convert nil to false and anything else into a boolean
       }
+      request_obj['context'] = context unless context.nil?
       request_obj['callback'] = callback unless callback.nil?
       request_obj['hostname'] = hostname unless hostname.nil?
 

--- a/lib/tozny/user.rb
+++ b/lib/tozny/user.rb
@@ -69,6 +69,29 @@ module Tozny
       raw_call request_obj
     end
 
+    # Create a magic link challenge session
+    #
+    # @param [String] destination The email address or phone number to which we will send a challenge
+    # @param [String] context     One of "verify," "authenticate," or "enroll"
+    # @param [String] callback    URL to which Tozny should submit signed link verification
+    # @param [String] hostname    Hostname for the generated OTP URL
+    # @param [Bool]   send        Flag whether or not to send the email (if false will return the OTP URL instead)
+    #
+    # @return [Hash] a hash of the session and presence for the challenge
+    #
+    def link_challenge(destination, context = nil, callback = nil, hostname = nil, send = true)
+      request_obj = {
+          method: 'user.link_challenge',
+          destination: destination,
+          send: !! send ? 'yes' : 'no' # Hacky double-bang to convert nil to false and anything else into a boolean
+      }
+      request_obj['context'] = context unless context.nil?
+      request_obj['callback'] = callback unless callback.nil?
+      request_obj['hostname'] = hostname unless hostname.nil?
+
+      raw_call request_obj
+    end
+
     # Check an OTP against an OTP session
     # @param [String] session_id the OTP session to validate
     # @param [String, Integer] otp the OTP to check
@@ -77,12 +100,15 @@ module Tozny
       raw_call(method: 'user.otp_result', session_id: session_id, otp: otp)
     end
 
-    # Verify an email-based OTP
-    # @param [String] otp The OTP to validate
+    # Verify a magic link OTP
+    #
+    # @param [String] otp The OTP (usually embedded in a magic link)to validate
+    #
     # @return [Hash] If successful, this request returns a redirect to the registered callback. Otherwise it returns a JSON array.
-    def email_result(otp)
+    #
+    def link_result(otp)
       params = {
-          method: 'user.email_result',
+          method: 'user.link_result',
           realm_key_id: realm_key_id,
           otp: otp
       }

--- a/lib/tozny/user.rb
+++ b/lib/tozny/user.rb
@@ -51,9 +51,10 @@ module Tozny
     # @param [String] type one of 'sms-otp-6', 'sms-otp-8': the type of the OTP to send
     # @param [String] destination the destination for the OTP. For an SMS OTP, this should be a phone number
     # @param [String] presence can be used instead of 'type' and 'destination': an OTP presence provided by the TOZNY API
+    # @param [String] context One of "verify," "authenticate," or "enroll"
     # @raise ArgumentError when not enough information to submit an OTP request
     # @raise ArgumentError on invalid request type
-    def otp_challenge(type = nil, destination = nil, presence = nil)
+    def otp_challenge(type = nil, destination = nil, presence = nil, context = nil)
       raise ArgumentError, 'must provide either a presence or a type and destination' if (type.nil? || destination.nil?) && presence.nil?
       request_obj = {
         method: 'user.otp_challenge'
@@ -66,6 +67,9 @@ module Tozny
       else
         request_obj[:presence] = presence
       end
+
+      request_obj[:context] = context unless context.nil?
+
       raw_call request_obj
     end
 

--- a/lib/tozny/user.rb
+++ b/lib/tozny/user.rb
@@ -77,6 +77,18 @@ module Tozny
       raw_call(method: 'user.otp_result', session_id: session_id, otp: otp)
     end
 
+    # Verify an email-based OTP
+    # @param [String] otp The OTP to validate
+    # @return [Hash] If successful, this request returns a redirect to the registered callback. Otherwise it returns a JSON array.
+    def email_result(otp)
+      params = {
+          method: 'user.email_result',
+          realm_key_id: realm_key_id,
+          otp: otp
+      }
+      raw_call(params)
+    end
+
     # Perform a raw(ish) API call
     # @param [Hash{Symbol, String => Object}] request_obj The request to conduct. Should include a :method at the least. Prefer symbol keys to string keys
     # @return [Object] The parsed result of the request. NOTE: most types will be stringified for most requests


### PR DESCRIPTION
Add support for the two new email-based OTP method calls:
- realm.email_challenge
- user.email_result

The other OTP method calls work as currently implemented.
